### PR TITLE
Changed CMake Version to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 # add modules
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")


### PR DESCRIPTION
As FindGLEW is required here, but isn't included in the cmake/modules folder i'd suggest chaning the cmake_minimum_required version atleast to 3.0 as it's the first version to ship that module (See http://www.cmake.org/cmake/help/v3.0/module/FindGLEW.html )
